### PR TITLE
Cache TravisCI's public key

### DIFF
--- a/travis.go
+++ b/travis.go
@@ -78,6 +78,8 @@ type Repository struct {
 	URL       string `json:"url,omitempty"`
 }
 
+var travisPubKey *rsa.PublicKey
+
 // GetPayload will parse the payload inside r
 func GetPayload(r io.Reader) (*Payload, error) {
 	if r == nil {
@@ -152,6 +154,11 @@ type configKey struct {
 }
 
 func travisPublicKey() (*rsa.PublicKey, error) {
+	/* check if TravisCI's public key is already stored locally */
+	if travisPubKey != nil {
+		return travisPubKey, nil
+	}
+
 	response, err := http.Get("https://api.travis-ci.org/config")
 
 	if err != nil {
@@ -171,7 +178,10 @@ func travisPublicKey() (*rsa.PublicKey, error) {
 		return nil, err
 	}
 
-	return key, nil
+	/* store public key locally */
+	travisPubKey = key
+
+	return travisPubKey, nil
 }
 
 func parsePublicKey(key string) (*rsa.PublicKey, error) {


### PR DESCRIPTION
Hi,

I just saw your lib over at [/r/golang](https://reddit.com/r/golang). I noticed you query the TravisCI-API each time a webhook arrives, because you always fetch TravisCI's public key.

To avoid doing a HTTP GET request on each travisPublicKey() call, you can simple cache the public key, like [I did in my travis webhook receiver](https://github.com/jacksgt/travishook/blob/master/travishook.go)